### PR TITLE
Sugarchain: fix: match download window to cached PoW (Yespower)

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -82,7 +82,7 @@ static const int MAX_SCRIPTCHECK_THREADS = 16;
 /** -par default (number of script-checking threads, 0 = auto) */
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 /** Number of blocks that can be requested at any given time from a single peer. */
-static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
+static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 2000; // yespower cache (BTC was 16) // 120x faster than bitcoin // 16*120=1920+80=2000
 /** Timeout in seconds during which a peer must stall block download progress before being disconnected. */
 static const unsigned int BLOCK_STALLING_TIMEOUT = 2;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends


### PR DESCRIPTION
### solardiz commented
Also relevant is ResistancePlatform/resistance-core@4efff30 which sets `MAX_BLOCKS_IN_TRANSIT_PER_PEER` to be same as `MAX_HEADERS_RESULTS`. Without this change, at least in Resistance the block headers download would get unnecessarily far ahead of the full blocks download, resulting in more work lost and redone in case the initial blocks download is interrupted and continued. The work loss is because we do not yet store cached PoWs on disk.

Don't change `MAX_HEADERS_RESULTS`. Just set `MAX_BLOCKS_IN_TRANSIT_PER_PEER` to some value from e.g. `200 to 2000` - experiment with this.
